### PR TITLE
Cache redis connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Travis Status](https://travis-ci.org/KabbageInc/django-redis-sentinel.svg?style=flat)](https://travis-ci.org/KabbageInc/django-redis-sentinel)
+[![Travis Status](https://api.travis-ci.org/SpatialBuzz/django-redis-sentinel.svg?branch=master)](https://travis-ci.org/SpatialBuzz/django-redis-sentinel)
 
 # django-redis-sentinel
 Plugin for django-redis that supports Redis Sentinel
@@ -27,3 +27,10 @@ In your settings, do something like this:
         }
     }
 ```
+
+## Settings
+These are top-level settings in settings.py
+
+`DJANGO_REDIS_SENTINEL_CLOSE_CONNECTION` - Close connection after each request, off will allow persistant connections (default `False`)
+`DJANGO_REDIS_READ_FROM_MASTER` - Allow reads on master (default `True`)
+`DJANGO_REDIS_ROLE_CHECK_TIME` - With persistant connections the master could change to a slave, this value specifes the min time period to check if the host is still master, if not it will query the sentinels again.

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,4 @@ pep8ignore =
     setup.py ALL
     settings.py ALL
     manage.py ALL
+    test_sentinel_client.py E302

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,4 @@ pretend==1.0.8
 cov-core==1.15.0
 coverage==3.7.1
 pytest-cov==1.8.1
-
-
+mock==2.0.0


### PR DESCRIPTION
Without connection caching the module will close the redis connection when a single request has completed, this change allows for connections to be cached per WSGI process.