### PR TITLE
Remove role check and replace discover_master/slaves

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,4 @@ In your settings, do something like this:
 ## Settings
 These are top-level settings in settings.py
 
-`DJANGO_REDIS_SENTINEL_CLOSE_CONNECTION` - Close connection after each request, off will allow persistant connections (default `False`)
-`DJANGO_REDIS_READ_FROM_MASTER` - Allow reads on master (default `True`)
-`DJANGO_REDIS_ROLE_CHECK_TIME` - With persistant connections the master could change to a slave, this value specifes the min time period to check if the host is still master, if not it will query the sentinels again.
+`DJANGO_REDIS_CLOSE_CONNECTION` - Close connection after each request, off will allow persistant connections (default `False`)


### PR DESCRIPTION
There is no need to check the role of the instances as when a Redis instance is reconfigured is sends CLIENT KILL which means the clients will need to rehandshake through the connect method and this will return the appropriate master/slave